### PR TITLE
Call the backend for a list of cached predictions and bookmarked the thumbnails

### DIFF
--- a/src/app/src/api/annotation.ts
+++ b/src/app/src/api/annotation.ts
@@ -16,6 +16,7 @@ import {
   MODEL_TAGS,
   PREDICT_VIDEO,
   LOADED_MODELS,
+  GET_CACHE_LIST,
 } from "@portal/constants/api";
 
 /* Annotation Type */
@@ -45,6 +46,7 @@ export interface AssetAPIObject {
   localPath: string;
   annotations: Array<AnnotationAPIObject>;
   type: string;
+  isCached: boolean;
   metadata: {
     height: number;
     width: number;
@@ -198,4 +200,8 @@ export function APIGetInferenceFlask(
       ...(filter ? { filter } : {}),
     },
   });
+}
+
+export function APIGetCacheList(modelKey: string): Promise<AxiosResponse<any>> {
+  return axios.get(SERVER_ADDRESS + GET_CACHE_LIST(modelKey));
 }

--- a/src/app/src/api/annotation.ts
+++ b/src/app/src/api/annotation.ts
@@ -16,7 +16,7 @@ import {
   MODEL_TAGS,
   PREDICT_VIDEO,
   LOADED_MODELS,
-  GET_CACHE_LIST,
+  CACHE_LIST,
 } from "@portal/constants/api";
 
 /* Annotation Type */
@@ -203,5 +203,11 @@ export function APIGetInferenceFlask(
 }
 
 export function APIGetCacheList(modelKey: string): Promise<AxiosResponse<any>> {
-  return axios.get(SERVER_ADDRESS + GET_CACHE_LIST(modelKey));
+  return axios.get(SERVER_ADDRESS + CACHE_LIST(modelKey));
+}
+
+export function APIDeleteCacheList(
+  modelKey: string
+): Promise<AxiosResponse<any>> {
+  return axios.delete(SERVER_ADDRESS + CACHE_LIST(modelKey));
 }

--- a/src/app/src/api/annotation.ts
+++ b/src/app/src/api/annotation.ts
@@ -162,9 +162,10 @@ export function APIGetModelTags(modelKey: string): Promise<AxiosResponse<any>> {
   return axios.get(SERVER_ADDRESS + MODEL_TAGS(modelKey));
 }
 
-export function APIGetVideoPrediction(
+export function APIGetVideoInference(
   modelKey: string,
   filepath: string,
+  reanalyse: boolean,
   frameInterval: number,
   iou?: number,
   confidence?: number,
@@ -175,6 +176,7 @@ export function APIGetVideoPrediction(
   return axios.get(route, {
     params: {
       filepath,
+      reanalyse,
       frameInterval,
       ...(iou ? { iou } : {}),
       ...(confidence ? { confidence } : {}),
@@ -183,9 +185,10 @@ export function APIGetVideoPrediction(
   });
 }
 
-export function APIGetInferenceFlask(
+export function APIGetImageInference(
   modelKey: string,
   filepath: string,
+  reanalyse: boolean,
   iou?: number,
   format?: string,
   filter?: string
@@ -195,6 +198,7 @@ export function APIGetInferenceFlask(
   return axios.get(route, {
     params: {
       filepath,
+      reanalyse,
       ...(iou ? { iou } : {}),
       ...(format ? { format } : {}),
       ...(filter ? { filter } : {}),

--- a/src/app/src/components/annotations/annotator.tsx
+++ b/src/app/src/components/annotations/annotator.tsx
@@ -668,12 +668,9 @@ export default class Annotator extends Component<
         .then(res => {
           this.setState({ cacheList: res.data });
         })
-        .catch(error => {
-          let message = `Failed to load cached predictions. ${error}`;
-          if (error.response) {
-            message = `${error.response.data.error}: ${error.response.data.message}`;
-          }
-          CreateGenericToast(message, Intent.DANGER, 3000);
+        .catch(() => {
+          /* Empty the cacheList since we can't get the list */
+          this.setState({ cacheList: [] });
         });
     }
   };
@@ -686,11 +683,9 @@ export default class Annotator extends Component<
       /* Generate New Asset List Based on Updated Data */
       const newImageAssets = res.data.map((encodedUri: string) => {
         const decodedUri = decodeURIComponent(encodedUri);
-        let seperator = "/";
-        let type = "image";
+        const seperator = decodedUri.includes("\\") ? "\\" : "/";
+        const type = decodedUri.match(/\.(?:mov|mp4|wmv)/i) ? "video" : "image";
         const isCached = this.state.cacheList.includes(encodedUri);
-        if (decodedUri.includes("\\")) seperator = "\\";
-        if (decodedUri.match(/\.(?:mov|mp4|wmv)/i)) type = "video";
         return {
           url: encodedUri,
           filename: decodedUri.split(seperator).pop(),

--- a/src/app/src/components/annotations/annotator.tsx
+++ b/src/app/src/components/annotations/annotator.tsx
@@ -666,15 +666,12 @@ export default class Annotator extends Component<
         .then(res => {
           this.setState({ cacheList: res.data });
         })
-        .catch(() => {
-          // TODO: Get rid when backend is done
-          this.setState({
-            cacheList: [
-              "d%3A%5Ctest%5Cpictures%5Canimals%5Cbicycle%20folder%5Cbicycle.jpg",
-              "d%3A%5Ctest%5Cpictures%5Canimals%5Cchip%20munk%5Cdog%20folder%5Cdog1.jpg",
-              "d%3A%5Ctest%5Cpictures%5Canimals%5Cchip%20munk%5Cchipmunk%20and%20pizza.jpg",
-            ],
-          });
+        .catch(error => {
+          let message = `Failed to load cached predictions. ${error}`;
+          if (error.response) {
+            message = `${error.response.data.error}: ${error.response.data.message}`;
+          }
+          CreateGenericToast(message, Intent.DANGER, 3000);
         });
     }
   };

--- a/src/app/src/components/annotations/annotator.tsx
+++ b/src/app/src/components/annotations/annotator.tsx
@@ -699,8 +699,14 @@ export default class Annotator extends Component<
     this.filterAnnotationVisibility();
   };
 
-  private updateCacheList = async () => {
+  /**
+   * Update ImageBar by reseting the cachelist and assetlist
+   */
+  private updateImage = async () => {
     if (this.props.loadedModel) {
+      /**
+       * Get list of files that has its prediction cached
+       */
       await APIGetCacheList(this.props.loadedModel.hash)
         .then(res => {
           this.setState({ cacheList: res.data });
@@ -710,10 +716,6 @@ export default class Annotator extends Component<
           this.setState({ cacheList: [] });
         });
     }
-  };
-
-  private updateImage = async () => {
-    await this.updateCacheList();
 
     /* Get All Existing Registered Folder and Image Assets */
     await APIGetAsset().then(res => {

--- a/src/app/src/components/annotations/annotator.tsx
+++ b/src/app/src/components/annotations/annotator.tsx
@@ -525,7 +525,7 @@ export default class Annotator extends Component<
     this.setState({ annotatedAssetsHidden: flag });
   }
 
-  private getInference(reanalyse: boolean) {
+  private getInference(reanalyse = true) {
     if (this.state.predictDone !== 0 || this.state.uiState === "Predicting") {
       CreateGenericToast("Inference is already running", Intent.WARNING, 3000);
       return;
@@ -932,10 +932,8 @@ export default class Annotator extends Component<
           }, 150);
           /* Reset to Default Zoom */
           this.map.setMinZoom(-3);
-          /** Get inference from cache */
-          if (asset.isCached) {
-            this.getInference(false);
-          }
+          /* Get inference if Image is Cached */
+          if (asset.isCached) this.getInference(false);
         }
 
         if (initialSelect) {
@@ -992,10 +990,8 @@ export default class Annotator extends Component<
             /** Set Focus */
             videoElement?.focus();
           }, 150);
-          /** Get inference from cache */
-          if (asset.isCached) {
-            this.getInference(false);
-          }
+          /* Get inference if Video is Cached */
+          if (asset.isCached) this.getInference(false);
         } else {
           /** Set Focus */
           videoElement?.focus();
@@ -1113,13 +1109,13 @@ export default class Annotator extends Component<
           global={true}
           combo={"r"}
           label={"Re-Analyse"}
-          onKeyDown={() => this.getInference(true)}
+          onKeyDown={() => this.getInference()}
         />
         <Hotkey
           global={true}
           combo={"b"}
           label={"Bulk Analysis"}
-          onKeyDown={() => this.getInference(true)}
+          onKeyDown={() => this.getInference()}
         />
         <Hotkey
           global={true}

--- a/src/app/src/components/annotations/imagebar.tsx
+++ b/src/app/src/components/annotations/imagebar.tsx
@@ -1,5 +1,12 @@
 import React, { Component } from "react";
-import { Card, Tag, Icon, IconSize } from "@blueprintjs/core";
+import {
+  Card,
+  Tag,
+  Icon,
+  IconSize,
+  Tooltip,
+  Position,
+} from "@blueprintjs/core";
 import { AssetAPIObject } from "@portal/api/annotation";
 import VideoThumbnail from "react-video-thumbnail";
 import classes from "./imagebar.module.css";
@@ -50,8 +57,16 @@ function ThumbnailGenerator(
           fill={true}
           style={{ backgroundColor: useDarkTheme ? "" : "#CED9E0" }}
           rightIcon={
-            (asset as any).status ? (
-              <Icon icon="tick" color={useDarkTheme ? "#0F9960" : "#3DCC91"} />
+            asset.isCached ? (
+              <Tooltip
+                content="Inference is Cached by Model"
+                position={Position.TOP}
+              >
+                <Icon
+                  icon="bookmark"
+                  color={useDarkTheme ? "#0F9960" : "#3DCC91"}
+                />
+              </Tooltip>
             ) : (
               false
             )

--- a/src/app/src/components/annotations/menu.jsx
+++ b/src/app/src/components/annotations/menu.jsx
@@ -369,7 +369,7 @@ export default class AnnotationMenu extends Component {
                 className={
                   this.props.userEditState === "Re-Analyse" ? "bp3-active" : ""
                 }
-                onClick={this.props.callbacks.GetInference}
+                onClick={() => this.props.callbacks.GetInference(true)}
               />
               <MenuItem
                 icon="heat-grid"
@@ -380,7 +380,7 @@ export default class AnnotationMenu extends Component {
                     ? "bp3-active"
                     : ""
                 }
-                onClick={this.props.callbacks.GetInference}
+                onClick={() => this.props.callbacks.GetInference(true)}
               />
             </>
           ) : (

--- a/src/app/src/components/annotations/menu.jsx
+++ b/src/app/src/components/annotations/menu.jsx
@@ -369,7 +369,7 @@ export default class AnnotationMenu extends Component {
                 className={
                   this.props.userEditState === "Re-Analyse" ? "bp3-active" : ""
                 }
-                onClick={() => this.props.callbacks.GetInference(true)}
+                onClick={() => this.props.callbacks.GetInference()}
               />
               <MenuItem
                 icon="heat-grid"
@@ -380,7 +380,7 @@ export default class AnnotationMenu extends Component {
                     ? "bp3-active"
                     : ""
                 }
-                onClick={() => this.props.callbacks.GetInference(true)}
+                onClick={() => this.props.callbacks.GetInference()}
               />
             </>
           ) : (

--- a/src/app/src/constants/api.js
+++ b/src/app/src/constants/api.js
@@ -33,6 +33,6 @@ export const PREDICT_VIDEO = modelKey => {
 export const GET_INFERENCE_FLASK = modelKey => {
   return `/api/model/${modelKey}/predict`;
 };
-export const GET_CACHE_LIST = modelKey => {
+export const CACHE_LIST = modelKey => {
   return `/api/model/${modelKey}/cachelist`;
 };

--- a/src/app/src/constants/api.js
+++ b/src/app/src/constants/api.js
@@ -33,3 +33,6 @@ export const PREDICT_VIDEO = modelKey => {
 export const GET_INFERENCE_FLASK = modelKey => {
   return `/api/model/${modelKey}/predict`;
 };
+export const GET_CACHE_LIST = modelKey => {
+  return `/api/model/${modelKey}/cachelist`;
+};


### PR DESCRIPTION
Overall changes made:
- Thumbnail of the pictures that has been cached has a `bookmark` icon wrapped with a ToolTip info "Inference is Cached by Model"
- Each time a picture with cached predictions is selected, it will silently call the prediction route. (Remove the progress bar but the spinner on the annotation menu still remains)

How the changes are made:
1. Add a `isCached` field in the AssetAPIObject type --> which will be used to check if the asset needs a `bookmark` icon on its thumbnail
2. Add a `cachedList` array which will be called and updated each time the imagebar needs to be updated (aka, refer below)
- ComponentDidMount
- ComponentDidUpdate (when the global loadedModel is updated)
- getInference (when a prediction is being called)