### PR TITLE
Bulk Analysis Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# electron
+*.log
+
+# production
+/application
+/dist
+/server/cache/store*
+
+# misc
+.DS_Store
+.env*
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# history
+.history
+
+# .vscode config
+/.vscode

--- a/src/app/src/api/annotation.ts
+++ b/src/app/src/api/annotation.ts
@@ -17,6 +17,7 @@ import {
   PREDICT_VIDEO,
   LOADED_MODELS,
   CACHE_LIST,
+  KILL_PREDICT_VIDEO,
 } from "@portal/constants/api";
 
 /* Annotation Type */
@@ -142,6 +143,10 @@ export function APIRegisterModel(
 
 export function APIGetLoadedModel(): Promise<AxiosResponse<any>> {
   return axios.get(SERVER_ADDRESS + LOADED_MODELS);
+}
+
+export function APIKillVideoInference(): Promise<AxiosResponse<any>> {
+  return axios.post(SERVER_ADDRESS + KILL_PREDICT_VIDEO);
 }
 
 export function APILoadModel(modelKey: string): Promise<AxiosResponse<any>> {

--- a/src/app/src/api/annotation.ts
+++ b/src/app/src/api/annotation.ts
@@ -141,12 +141,12 @@ export function APIRegisterModel(
   return axios.post(SERVER_ADDRESS + REGISTER_MODEL, config);
 }
 
-export function APIGetLoadedModel(): Promise<AxiosResponse<any>> {
-  return axios.get(SERVER_ADDRESS + LOADED_MODELS);
-}
-
 export function APIKillVideoInference(): Promise<AxiosResponse<any>> {
   return axios.post(SERVER_ADDRESS + KILL_PREDICT_VIDEO);
+}
+
+export function APIGetLoadedModel(): Promise<AxiosResponse<any>> {
+  return axios.get(SERVER_ADDRESS + LOADED_MODELS);
 }
 
 export function APILoadModel(modelKey: string): Promise<AxiosResponse<any>> {

--- a/src/app/src/components/annotations/annotator.tsx
+++ b/src/app/src/components/annotations/annotator.tsx
@@ -119,6 +119,7 @@ interface AnnotatorState {
     /* Intersection over Union */
     iou: number;
     cacheResults: boolean;
+    bulkAnalysisStatus: string;
     video: {
       /* Frame interval to produce predictions for video */
       frameInterval: number;
@@ -212,6 +213,7 @@ export default class Annotator extends Component<
       filterArr: [],
       showSelected: true,
       inferenceOptions: {
+        bulkAnalysisStatus: "both",
         cacheResults: false,
         iou: 0.8,
         video: {
@@ -704,6 +706,9 @@ export default class Annotator extends Component<
   private handleChangeInAdvancedSettings = (value: any, key: string) => {
     this.setState(prevState => {
       const settings = prevState.inferenceOptions;
+      if (key === "bulkAnalysisStatus") {
+        settings.bulkAnalysisStatus = value;
+      }
       if (key === "frameInterval") {
         settings.video.frameInterval = value;
       }

--- a/src/app/src/components/annotations/annotator.tsx
+++ b/src/app/src/components/annotations/annotator.tsx
@@ -619,6 +619,7 @@ export default class Annotator extends Component<
       })
     );
 
+    await this.updateImage();
     this.setState({ predictDone: 0, uiState: null });
   }
 

--- a/src/app/src/components/annotations/menu.jsx
+++ b/src/app/src/components/annotations/menu.jsx
@@ -380,7 +380,7 @@ export default class AnnotationMenu extends Component {
                     ? "bp3-active"
                     : ""
                 }
-                onClick={this.props.callbacks.GetInference}
+                onClick={this.props.callbacks.BulkAnalysis}
               />
             </>
           ) : (

--- a/src/app/src/components/annotations/menu.jsx
+++ b/src/app/src/components/annotations/menu.jsx
@@ -369,7 +369,7 @@ export default class AnnotationMenu extends Component {
                 className={
                   this.props.userEditState === "Re-Analyse" ? "bp3-active" : ""
                 }
-                onClick={() => this.props.callbacks.GetInference()}
+                onClick={() => this.props.callbacks.SingleAnalysis()}
               />
               <MenuItem
                 icon="heat-grid"

--- a/src/app/src/components/annotations/settingsmodal.tsx
+++ b/src/app/src/components/annotations/settingsmodal.tsx
@@ -9,6 +9,8 @@ import {
   Slider,
   Position,
   ControlGroup,
+  RadioGroup,
+  Radio,
 } from "@blueprintjs/core";
 import classes from "./settingsmodal.module.css";
 
@@ -43,6 +45,32 @@ export default class SettingsModal extends React.Component<SettingsModalProps> {
         <div className={classes.Dialog}>
           <div className={Classes.DIALOG_BODY}>
             <div>General</div>
+            <div className={classes.Section}>
+              <ControlGroup className={classes.SubTitle}>
+                <div>Bulk Analysis</div>
+                <Tooltip
+                  content="Types of files to analyse in bulk"
+                  position={Position.TOP}
+                >
+                  <Icon icon="help" className={classes.Icon} />
+                </Tooltip>
+              </ControlGroup>
+              <RadioGroup
+                inline={true}
+                name="bulkAnalysisStatus"
+                onChange={event => {
+                  this.props.callbacks.HandleChangeInSettings(
+                    event.currentTarget.value,
+                    "bulkAnalysisStatus"
+                  );
+                }}
+                selectedValue={this.props.inferenceOptions.bulkAnalysisStatus}
+              >
+                <Radio label="Image Only" value="image" />
+                <Radio label="Video Only" value="video" />
+                <Radio label="Image and Video" value="both" />
+              </RadioGroup>
+            </div>
             <div className={classes.Section}>
               <ControlGroup className={classes.SubTitle}>
                 <div>IoU</div>

--- a/src/app/src/constants/api.js
+++ b/src/app/src/constants/api.js
@@ -15,6 +15,7 @@ export const DELETE_PROJECT_ASSETS = `/api/project/`;
 export const MODEL = `/api/model`;
 export const REGISTER_MODEL = `/api/model/register`;
 export const LOADED_MODELS = `/api/model/loadedList`;
+export const KILL_PREDICT_VIDEO = `/api/model/predict/video/kill`;
 export const LOAD_MODEL = modelKey => {
   return `/api/model/${modelKey}/load`;
 };

--- a/src/engine/Pipfile
+++ b/src/engine/Pipfile
@@ -18,7 +18,6 @@ apscheduler = "==3.7.0"
 datature-hub = "==0.1.0"
 pillow = "==8.2.0"
 
-
 [dev-packages]
 pylint = "*"
 isort = "*"

--- a/src/engine/Pipfile.lock
+++ b/src/engine/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5d5cbcaca7d260e5b263bf4446217a06ae300bab827e70b21d578d981803f4f1"
+            "sha256": "374c6ba974b154b75ddc41088b13ec653ed517455676ec617028f7d7e356076f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -52,6 +52,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.2.0"
+        },
+        "bidict": {
+            "hashes": [
+                "sha256:4fa46f7ff96dc244abfc437383d987404ae861df797e2fd5b190e233c302be09",
+                "sha256:929d056e8d0d9b17ceda20ba5b24ac388e2a4d39802b87f9f4d3f45ecba070bf"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.21.2"
         },
         "cachetools": {
             "hashes": [
@@ -132,14 +140,14 @@
             "index": "pypi",
             "version": "==0.3.9"
         },
-		"flask-socketio": {
-			"hashes": [
-				"sha256:68ae373a41d906819f5129d4d28ad062fcf0085dd06424753a79ca47de509ab5",
-				"sha256:b41b9f6fb0d7f3fcadd54c44653307a9b96e985c7da73f92779480248b5b6874"
-			],
-			"index": "pypi",
-			"version": "==5.1.0"
-		},
+        "flask-socketio": {
+            "hashes": [
+                "sha256:68ae373a41d906819f5129d4d28ad062fcf0085dd06424753a79ca47de509ab5",
+                "sha256:b41b9f6fb0d7f3fcadd54c44653307a9b96e985c7da73f92779480248b5b6874"
+            ],
+            "index": "pypi",
+            "version": "==5.1.0"
+        },
         "gast": {
             "hashes": [
                 "sha256:8f46f5be57ae6889a4e16e2ca113b1703ef17f2b0abceb83793eaba9e1351a45",
@@ -150,11 +158,11 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:b3a67fa9ba5b768861dacf374c2135eb09fa14a0e40c851c3b8ea7abe6fc8fef",
-                "sha256:e34e5f5de5610b202f9b40ebd9f8b27571d5c5537db9afed3a72b2db5a345039"
+                "sha256:9266252e11393943410354cf14a77bcca24dd2ccd9c4e1aef23034fe0fbae630",
+                "sha256:c7c215c74348ef24faef2f7b62f6d8e6b38824fe08b1e7b7b09a02d397eda7b3"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.32.0"
+            "version": "==1.32.1"
         },
         "google-auth-oauthlib": {
             "hashes": [
@@ -272,11 +280,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:833b26fb89d5de469b24a390e9df088d4e52e4ba33b01dc5e0e4f41b81a16c00",
-                "sha256:b142cc1dd1342f31ff04bb7d022492b09920cb64fed867cd3ea6f80fe3ebd139"
+                "sha256:4a5611fea3768d3d967c447ab4e93f567d95db92225b43b7b238dbfb855d70bb",
+                "sha256:c6513572926a96458f8c8f725bf0e00108fba0c9583ade9bd15b869c9d726e33"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==4.5.0"
+            "version": "==4.6.0"
         },
         "itsdangerous": {
             "hashes": [
@@ -488,19 +496,23 @@
                 "sha256:2ae692bb6d1992afb6b74348e7bb648a75bb0d3565a3f5eea5bec8f62bd06d87",
                 "sha256:2bfb815216a9cd9faec52b16fd2bfa68437a44b67c56bee59bc3926522ecb04e",
                 "sha256:4ffbd23640bb7403574f7aff8368e2aeb2ec9a5c6306580be48ac59a6bac8bde",
+                "sha256:59e5cf6b737c3a376932fbfb869043415f7c16a0cf176ab30a5bbc419cd709c1",
                 "sha256:6902a1e4b7a319ec611a7345ff81b6b004b36b0d2196ce7a748b3493da3d226d",
                 "sha256:6ce4d8bf0321e7b2d4395e253f8002a1a5ffbcfd7bcc0a6ba46712c07d47d0b4",
                 "sha256:6d847c59963c03fd7a0cd7c488cadfa10cda4fff34d8bc8cba92935a91b7a037",
                 "sha256:72804ea5eaa9c22a090d2803813e280fb273b62d5ae497aaf3553d141c4fdd7b",
                 "sha256:7a4c97961e9e5b03a56f9a6c82742ed55375c4a25f2692b625d4087d02ed31b9",
+                "sha256:85d6303e4adade2827e43c2b54114d9a6ea547b671cb63fafd5011dc47d0e13d",
                 "sha256:8727ee027157516e2c311f218ebf2260a18088ffb2d29473e82add217d196b1c",
                 "sha256:99938f2a2d7ca6563c0ade0c5ca8982264c484fdecf418bd68e880a7ab5730b1",
                 "sha256:9b7a5c1022e0fa0dbde7fd03682d07d14624ad870ae52054849d8960f04bc764",
                 "sha256:a22b3a0dbac6544dacbafd4c5f6a29e389a50e3b193e2c70dae6bbf7930f651d",
+                "sha256:a38bac25f51c93e4be4092c88b2568b9f407c27217d3dd23c7a57fa522a17554",
                 "sha256:a981222367fb4210a10a929ad5983ae93bd5a050a0824fc35d6371c07b78caf6",
                 "sha256:ab6bb0e270c6c58e7ff4345b3a803cc59dbee19ddf77a4719c5b635f1d547aa8",
                 "sha256:c56c050a947186ba51de4f94ab441d7f04fcd44c56df6e922369cc2e1a92d683",
                 "sha256:e76d9686e088fece2450dbc7ee905f9be904e427341d289acbe9ad00b78ebd47",
+                "sha256:ebcb546f10069b56dc2e3da35e003a02076aaa377caf8530fe9789570984a8d2",
                 "sha256:f0e59430ee953184a703a324b8ec52f571c6c4259d496a19d1cabcdc19dabc62",
                 "sha256:ffea251f5cd3c0b9b43c7a7a912777e0bc86263436a87c2555242a348817221b"
             ],
@@ -541,6 +553,20 @@
                 "sha256:fe0644d9ab041506b62782e92b06b8c68cca799e1a9636ec398675459e031405"
             ],
             "version": "==0.2.8"
+        },
+        "python-engineio": {
+            "hashes": [
+                "sha256:4e97c1189c23923858f5bb6dc47cfcd915005383c3c039ff01c89f2c00d62077",
+                "sha256:c6c119c2039fcb6f64d260211ca92c0c61b2b888a28678732a961f2aaebcc848"
+            ],
+            "version": "==4.2.0"
+        },
+        "python-socketio": {
+            "hashes": [
+                "sha256:3dcc9785aaeef3a9eeb36c3818095662342744bdcdabd050fe697cdb826a1c2b",
+                "sha256:d74314fd4241342c8a55c4f66d5cfea8f1a8fffd157af216c67e1c3a649a2444"
+            ],
+            "version": "==5.3.0"
         },
         "pytz": {
             "hashes": [
@@ -701,11 +727,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c",
-                "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
+                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.5"
+            "version": "==1.26.6"
         },
         "werkzeug": {
             "hashes": [
@@ -741,11 +767,11 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:4db03ab5fc3340cf619dbc25e42c2cc3755154ce6009469766d7143d1fc2ee4e",
-                "sha256:8a398dfce302c13f14bab13e2b14fe385d32b73f4e4853b9bdfb64598baa1975"
+                "sha256:38b95085e9d92e2ca06cf8b35c12a74fa81da395a6f9e65803742e6509c05892",
+                "sha256:606b2911d10c3dcf35e58d2ee5c97360e8477d7b9f3efc3f24811c93e6fc2cd9"
             ],
             "markers": "python_version ~= '3.6'",
-            "version": "==2.5.6"
+            "version": "==2.6.2"
         },
         "colorama": {
             "hashes": [
@@ -800,11 +826,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:0a049c5d47b629d9070c3932d13bff482b12119b6a241a93bc460b0be16953c8",
-                "sha256:792b38ff30903884e4a9eab814ee3523731abd3c463f3ba48d7b627e87013484"
+                "sha256:23a1dc8b30459d78e9ff25942c61bb936108ccbe29dd9e71c01dc8274961709a",
+                "sha256:5d46330e6b8886c31b5e3aba5ff48c10f4aa5e76cbf9002c6544306221e63fbc"
             ],
             "index": "pypi",
-            "version": "==2.8.3"
+            "version": "==2.9.3"
         },
         "toml": {
             "hashes": [
@@ -849,6 +875,15 @@
             ],
             "markers": "python_version < '3.8' and implementation_name == 'cpython'",
             "version": "==1.4.3"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
+                "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
+                "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==3.10.0.0"
         },
         "wrapt": {
             "hashes": [

--- a/src/engine/server/routes/routes.py
+++ b/src/engine/server/routes/routes.py
@@ -511,7 +511,7 @@ def predict_video_fn(model_id: str) -> tuple:
             str(frame_interval) + str(iou) + str(confidence),
         )
         prediction_status = (
-            "predict_single_image_"
+            "predict_video_"
             + model_id
             + video_directory
             + str(frame_interval)

--- a/src/engine/server/routes/routes.py
+++ b/src/engine/server/routes/routes.py
@@ -291,7 +291,7 @@ def deregister_model(model_id: str) -> Response:
         raise PortalError(Errors.INVALIDMODELKEY, str(e)) from e
 
 
-@app.route("/api/model/", methods=["GET"])
+@app.route("/api/model", methods=["GET"])
 @cross_origin()
 @portal_function_handler(clear_status=False)
 def get_registry() -> tuple:


### PR DESCRIPTION
HotKey `B` and the menu item bulk analysis button will invoke `bulkAnalysis()` method which goes through the entire assetList to get inference for each of the asset.

Under the Advance Settings, the User is able to choose if they want the bulk analysis to include `Image Only`, `Video Only` or `Image and Video`

![image](https://user-images.githubusercontent.com/46533056/123936721-0e356900-d9c8-11eb-8b19-c5a642782fee.png)


Includes end bulk analysis and end video prediction. Does not work for ending image prediction