### PR TITLE
replace tag display predicate from .includes to ===

### DIFF
--- a/src/app/src/components/annotations/menu.jsx
+++ b/src/app/src/components/annotations/menu.jsx
@@ -240,8 +240,8 @@ export default class AnnotationMenu extends Component {
               guard against some returning false on empty arrays */
               this.props.filterArr.length === 0 ||
               /* Check if tag is present in filter (CASE-INSENSITIVE) */
-              this.props.filterArr.some(filter =>
-                tag.toLowerCase().includes(filter.toLowerCase())
+              this.props.filterArr.some(
+                filter => tag.toLowerCase() === filter.toLowerCase()
               ) === this.props.showSelected
           )
           /* Update mapping */


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/58349087/124854846-92947700-dfda-11eb-9570-fc9aa60a2de0.png)

This model has label maps car and carrot. previously, using the search term car, with the .includes() predicate car carrot will also display but now with the === predicate filtering will only return cars